### PR TITLE
fix: drop Drupal 9 support

### DIFF
--- a/localgov_sa11y.info.yml
+++ b/localgov_sa11y.info.yml
@@ -2,4 +2,4 @@ name: LocalGov Sa11y
 type: module
 description: Applies the Sa11y accessibility checker to LocalGov Drupal websites.
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10 || ^11


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

As mentioned on MT, dropping Drupal 9 from the supported list as we no longer support or test against this version