### PR TITLE
Add configuration options

### DIFF
--- a/js/localgov-sa11y.js
+++ b/js/localgov-sa11y.js
@@ -1,26 +1,22 @@
 (function sa11yScript(Drupal, drupalSettings) {
   Drupal.behaviors.sa11y = {
     attach: function (context, settings) {
-      console.log (drupalSettings.localgov_sa11y_options);
+
       const checkRootSetting = (drupalSettings.localgov_sa11y_options.checkRoot) ? drupalSettings.localgov_sa11y_options.checkRoot : 'div.dialog-off-canvas-main-canvas';
       const containerIgnoreSetting = (drupalSettings.localgov_sa11y_options.containerIgnore) ? drupalSettings.localgov_sa11y_options.containerIgnore.replace(/\n/g, ",") : '';
       const contrastIgnoreSetting = (drupalSettings.localgov_sa11y_options.contrastIgnore) ? drupalSettings.localgov_sa11y_options.contrastIgnore.replace(/\n/g, ",") : '';
+      const linkIgnoreSetting = (drupalSettings.localgov_sa11y_options.linkIgnore) ? drupalSettings.localgov_sa11y_options.linkIgnore.replace(/\n/g, ",") : '';
       const exportResultsPluginSetting = (drupalSettings.localgov_sa11y_options.exportResultsPlugin) ? drupalSettings.localgov_sa11y_options.exportResultsPlugin : 0;
       const checkAllHideTogglesSetting = (drupalSettings.localgov_sa11y_options.checkAllHideToggles) ? drupalSettings.localgov_sa11y_options.checkAllHideToggles : 0;
       const panelPositionSetting = (drupalSettings.localgov_sa11y_options.panelPosition) ? drupalSettings.localgov_sa11y_options.panelPosition : 'right';
-      console.log(checkRootSetting);
-      console.log(containerIgnoreSetting);
-      console.log(contrastIgnoreSetting);
-      console.log(exportResultsPluginSetting);
-      console.log(checkAllHideTogglesSetting);
-      console.log(panelPositionSetting);
-      
+
       context = context || document;
       Sa11y.Lang.addI18n(Sa11yLangEn.strings);
       const sa11y = new Sa11y.Sa11y({
         checkRoot: checkRootSetting,
         containerIgnore: containerIgnoreSetting,
         contrastIgnore: contrastIgnoreSetting,
+        linkIgnore: linkIgnoreSetting,
         exportResultsPlugin: exportResultsPluginSetting,
         checkAllHideToggles: checkAllHideTogglesSetting,
         panelPosition: panelPositionSetting,

--- a/js/localgov-sa11y.js
+++ b/js/localgov-sa11y.js
@@ -1,11 +1,30 @@
-(function sa11yScript(Drupal) {
+(function sa11yScript(Drupal, drupalSettings) {
   Drupal.behaviors.sa11y = {
     attach: function (context, settings) {
+      console.log (drupalSettings.localgov_sa11y_options);
+      const checkRootSetting = (drupalSettings.localgov_sa11y_options.checkRoot) ? drupalSettings.localgov_sa11y_options.checkRoot : 'div.dialog-off-canvas-main-canvas';
+      const containerIgnoreSetting = (drupalSettings.localgov_sa11y_options.containerIgnore) ? drupalSettings.localgov_sa11y_options.containerIgnore.replace(/\n/g, ",") : '';
+      const contrastIgnoreSetting = (drupalSettings.localgov_sa11y_options.contrastIgnore) ? drupalSettings.localgov_sa11y_options.contrastIgnore.replace(/\n/g, ",") : '';
+      const exportResultsPluginSetting = (drupalSettings.localgov_sa11y_options.exportResultsPlugin) ? drupalSettings.localgov_sa11y_options.exportResultsPlugin : 0;
+      const checkAllHideTogglesSetting = (drupalSettings.localgov_sa11y_options.checkAllHideToggles) ? drupalSettings.localgov_sa11y_options.checkAllHideToggles : 0;
+      const panelPositionSetting = (drupalSettings.localgov_sa11y_options.panelPosition) ? drupalSettings.localgov_sa11y_options.panelPosition : 'right';
+      console.log(checkRootSetting);
+      console.log(containerIgnoreSetting);
+      console.log(contrastIgnoreSetting);
+      console.log(exportResultsPluginSetting);
+      console.log(checkAllHideTogglesSetting);
+      console.log(panelPositionSetting);
+      
       context = context || document;
       Sa11y.Lang.addI18n(Sa11yLangEn.strings);
       const sa11y = new Sa11y.Sa11y({
-        checkRoot: "div.dialog-off-canvas-main-canvas",
+        checkRoot: checkRootSetting,
+        containerIgnore: containerIgnoreSetting,
+        contrastIgnore: contrastIgnoreSetting,
+        exportResultsPlugin: exportResultsPluginSetting,
+        checkAllHideToggles: checkAllHideTogglesSetting,
+        panelPosition: panelPositionSetting,
       });
     },
   };
-})(Drupal);
+})(Drupal, drupalSettings);

--- a/localgov_sa11y.libraries.yml
+++ b/localgov_sa11y.libraries.yml
@@ -3,6 +3,7 @@ localgov_sa11y:
     js/localgov-sa11y.js: {}
   dependencies:
     - core/drupal
+    - core/drupalSettings
     - localgov_sa11y/sa11y-files
 
 sa11y-files:

--- a/localgov_sa11y.links.menu.yml
+++ b/localgov_sa11y.links.menu.yml
@@ -1,0 +1,6 @@
+localgov_sa11y.admin_settings:
+  title: 'localgov_sa11y Settings'
+  description: 'Settings for the Sa11y App'
+  route_name: localgov_sa11y.admin_settings
+  parent: system.admin_config_system
+  weight: 10

--- a/localgov_sa11y.links.menu.yml
+++ b/localgov_sa11y.links.menu.yml
@@ -1,6 +1,6 @@
 localgov_sa11y.admin_settings:
-  title: 'localgov_sa11y Settings'
+  title: 'LocalGov Sa11y Settings'
   description: 'Settings for the Sa11y App'
   route_name: localgov_sa11y.admin_settings
-  parent: system.admin_config_system
+  parent: system.admin_config_content
   weight: 10

--- a/localgov_sa11y.module
+++ b/localgov_sa11y.module
@@ -16,4 +16,13 @@ function localgov_sa11y_page_attachments(array &$page) {
   if (\Drupal::currentUser()->hasPermission('use_localgov_sa11y') && !$using_admin_theme) {
     $page['#attached']['library'][] = 'localgov_sa11y/localgov_sa11y';
   }
+
+  $config = \Drupal::configFactory()->get('localgov_sa11y_options.settings');
+
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['checkRoot'] = $config->get('checkRoot');
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['containerIgnore'] = $config->get('containerIgnore');
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['contrastIgnore'] = $config->get('contrastIgnore');
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['exportResultsPlugin'] = $config->get('exportResultsPlugin');
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['checkAllHideToggles'] = $config->get('checkAllHideToggles');
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['panelPosition'] = $config->get('panelPosition');
 }

--- a/localgov_sa11y.module
+++ b/localgov_sa11y.module
@@ -21,7 +21,8 @@ function localgov_sa11y_page_attachments(array &$page) {
 
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['checkRoot'] = $config->get('checkRoot');
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['containerIgnore'] = $config->get('containerIgnore');
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['contrastIgnore'] = $config->get('contrastIgnore');
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['contrastIgnore'] = $config->get('contrastIgnore'); 
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['linkIgnore'] = $config->get('linkIgnore'); 
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['exportResultsPlugin'] = $config->get('exportResultsPlugin');
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['checkAllHideToggles'] = $config->get('checkAllHideToggles');
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['panelPosition'] = $config->get('panelPosition');

--- a/localgov_sa11y.module
+++ b/localgov_sa11y.module
@@ -21,8 +21,8 @@ function localgov_sa11y_page_attachments(array &$page) {
 
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['checkRoot'] = $config->get('checkRoot');
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['containerIgnore'] = $config->get('containerIgnore');
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['contrastIgnore'] = $config->get('contrastIgnore'); 
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['linkIgnore'] = $config->get('linkIgnore'); 
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['contrastIgnore'] = $config->get('contrastIgnore');
+  $page['#attached']['drupalSettings']['localgov_sa11y_options']['linkIgnore'] = $config->get('linkIgnore');
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['exportResultsPlugin'] = $config->get('exportResultsPlugin');
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['checkAllHideToggles'] = $config->get('checkAllHideToggles');
   $page['#attached']['drupalSettings']['localgov_sa11y_options']['panelPosition'] = $config->get('panelPosition');

--- a/localgov_sa11y.permissions.yml
+++ b/localgov_sa11y.permissions.yml
@@ -1,3 +1,7 @@
 use_localgov_sa11y:
   title: 'Use LocalGov Sa11y'
   restrict access: true
+
+administer localgov_sa11y settings:
+  title: 'Administer localgov_sa11y settings'
+  restrict access: false

--- a/localgov_sa11y.routing.yml
+++ b/localgov_sa11y.routing.yml
@@ -1,0 +1,7 @@
+localgov_sa11y.admin_settings:
+  path: '/admin/config/system/localgov-sa11y'
+  defaults:
+    _form: '\Drupal\localgov_sa11y\Form\Sa11yOptionsForm'
+    _title: 'localgov_sa11y settings'
+  requirements:
+    _permission: 'administer localgov_sa11y settings'

--- a/localgov_sa11y.routing.yml
+++ b/localgov_sa11y.routing.yml
@@ -1,5 +1,5 @@
 localgov_sa11y.admin_settings:
-  path: '/admin/config/system/localgov-sa11y'
+  path: '/admin/config/content/localgov-sa11y'
   defaults:
     _form: '\Drupal\localgov_sa11y\Form\Sa11yOptionsForm'
     _title: 'localgov_sa11y settings'

--- a/src/Form/Sa11yOptionsForm.php
+++ b/src/Form/Sa11yOptionsForm.php
@@ -1,17 +1,20 @@
-<?php  
+<?php
 
 namespace Drupal\localgov_sa11y\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-  
+
+/**
+ * Settings form for localgov_sa11y options.
+ */
 class Sa11yOptionsForm extends ConfigFormBase {
 
   const LOCALGOV_SA11Y_SETTINGS = 'localgov_sa11y_options_form';
 
-   /**
-   * {@inheritdoc}
-   */
+  /**
+    * {@inheritdoc}
+    */
   protected function getEditableConfigNames() {
     return [
       'localgov_sa11y_options.settings',
@@ -35,7 +38,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
     $form['checkRoot'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Check Root: A single selector to scan a specific region of the page'),
-      '#description' => $this->t('A single selector to scan a specific region of the page. This selector should exist on every page of your website. (Default: \'div.dialog-off-canvas-main-canvas\') '),
+      '#description' => $this->t('A single selector to scan a specific region of the page. This selector should exist on every page of your website. (Default: "div.dialog-off-canvas-main-canvas")'),
       '#default_value' => !empty($default_checkRoot_value) ? $default_checkRoot_value : 'div.dialog-off-canvas-main-canvas',
       '#required' => TRUE,
     ];
@@ -44,7 +47,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
     $form['containerIgnore'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Container Ignore: Ignore specific regions of the page'),
-      '#description' => $this->t('List of CSS selectors to have Sa11y completely ignore specifc regions of the page - add each selector on a separate line (Default: \'\') '),
+      '#description' => $this->t('List of CSS selectors to have Sa11y completely ignore specifc regions of the page - add each selector on a separate line (Default: "")'),
       '#default_value' => !empty($default_containerIgnore_value) ? $default_containerIgnore_value : '',
       '#required' => FALSE,
     ];
@@ -53,7 +56,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
     $form['contrastIgnore'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Contrast Ignore: Ignore specific elements from the contrast check'),
-      '#description' => $this->t('List of CSS selectors to have sa11y ignore specific elements from the contrast check - add each selector on a separate line (Default: \'\') '),
+      '#description' => $this->t('List of CSS selectors to have sa11y ignore specific elements from the contrast check - add each selector on a separate line (Default: "")'),
       '#default_value' => !empty($default_contrastIgnore_value) ? $default_contrastIgnore_value : '',
       '#required' => FALSE,
     ];
@@ -62,7 +65,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
     $form['linkIgnore'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Link Ignore: Ignore specific links on the page'),
-      '#description' => $this->t('List of CSS selectors to have sa11y ignore specific links on the page - add each selector on a separate line (Default: \'\') '),
+      '#description' => $this->t('List of CSS selectors to have sa11y ignore specific links on the page - add each selector on a separate line (Default: "")'),
       '#default_value' => !empty($default_linkIgnore_value) ? $default_linkIgnore_value : '',
       '#required' => FALSE,
     ];
@@ -71,7 +74,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
     $form['exportResultsPlugin'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Allow "Export Reports"?'),
-      '#description' => $this->t('Select if you would like to add buttons that allow users to export issues as CSV or HTML (Default: FALSE) '),
+      '#description' => $this->t('Select if you would like to add buttons that allow users to export issues as CSV or HTML (Default: FALSE)'),
       '#default_value' => !empty($default_exportResultsPlugin_value) ? $default_exportResultsPlugin_value : FALSE,
       '#required' => FALSE,
     ];
@@ -80,7 +83,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
     $form['checkAllHideToggles'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Visually hide all toggle switches?'),
-      '#description' => $this->t('Select if you would like to visually hide all toggle switches in the Settings panel. This will not hide the Readability, Dark Mode, or Colour Filter toggles (Default: FALSE) '),
+      '#description' => $this->t('Select if you would like to visually hide all toggle switches in the Settings panel. This will not hide the Readability, Dark Mode, or Colour Filter toggles (Default: FALSE)'),
       '#default_value' => !empty($default_checkAllHideToggles_value) ? $default_checkAllHideToggles_value : FALSE,
       '#required' => FALSE,
     ];
@@ -95,7 +98,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
         'top-left' => t('top-left'),
       ],
       '#title' => $this->t('Panel position'),
-      '#description' => $this->t('Move position of panel in any four corners. Choose from top-left, top-right, left, and right (Default: \'right\') '),
+      '#description' => $this->t('Move position of panel in any four corners. Choose from top-left, top-right, left, and right (Default: "right")'),
       '#default_value' => !empty($default_panelPosition_value) ? $default_panelPosition_value : 'right',
       '#required' => TRUE,
     ];

--- a/src/Form/Sa11yOptionsForm.php
+++ b/src/Form/Sa11yOptionsForm.php
@@ -58,6 +58,15 @@ class Sa11yOptionsForm extends ConfigFormBase {
       '#required' => FALSE,
     ];
 
+    $default_linkIgnore_value = $config->get('linkIgnore');
+    $form['linkIgnore'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Link Ignore: Ignore specific links on the page'),
+      '#description' => $this->t('List of CSS selectors to have sa11y ignore specific links on the page - add each selector on a separate line (Default: \'\') '),
+      '#default_value' => !empty($default_linkIgnore_value) ? $default_linkIgnore_value : '',
+      '#required' => FALSE,
+    ];
+
     $default_exportResultsPlugin_value = $config->get('exportResultsPlugin');
     $form['exportResultsPlugin'] = [
       '#type' => 'checkbox',

--- a/src/Form/Sa11yOptionsForm.php
+++ b/src/Form/Sa11yOptionsForm.php
@@ -4,11 +4,14 @@ namespace Drupal\localgov_sa11y\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Settings form for localgov_sa11y options.
  */
 class Sa11yOptionsForm extends ConfigFormBase {
+  
+  use StringTranslationTrait;
 
   const LOCALGOV_SA11Y_SETTINGS = 'localgov_sa11y_options_form';
 

--- a/src/Form/Sa11yOptionsForm.php
+++ b/src/Form/Sa11yOptionsForm.php
@@ -95,10 +95,10 @@ class Sa11yOptionsForm extends ConfigFormBase {
     $form['panelPosition'] = [
       '#type' => 'select',
       '#options' => [
-        'right' =>  $this->t('right'),
-        'left' =>  $this->t('left'),
-        'top-right' =>  $this->t('top-right'),
-        'top-left' =>  $this->t('top-left'),
+        'right' => $this->t('right'),
+        'left' => $this->t('left'),
+        'top-right' => $this->t('top-right'),
+        'top-left' => $this->t('top-left'),
       ],
       '#title' => $this->t('Panel position'),
       '#description' => $this->t('Move position of panel in any four corners. Choose from top-left, top-right, left, and right (Default: "right")'),

--- a/src/Form/Sa11yOptionsForm.php
+++ b/src/Form/Sa11yOptionsForm.php
@@ -10,7 +10,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  * Settings form for localgov_sa11y options.
  */
 class Sa11yOptionsForm extends ConfigFormBase {
-  
+
   use StringTranslationTrait;
 
   const LOCALGOV_SA11Y_SETTINGS = 'localgov_sa11y_options_form';
@@ -95,10 +95,10 @@ class Sa11yOptionsForm extends ConfigFormBase {
     $form['panelPosition'] = [
       '#type' => 'select',
       '#options' => [
-        'right' => t('right'),
-        'left' => t('left'),
-        'top-right' => t('top-right'),
-        'top-left' => t('top-left'),
+        'right' =>  $this->t('right'),
+        'left' =>  $this->t('left'),
+        'top-right' =>  $this->t('top-right'),
+        'top-left' =>  $this->t('top-left'),
       ],
       '#title' => $this->t('Panel position'),
       '#description' => $this->t('Move position of panel in any four corners. Choose from top-left, top-right, left, and right (Default: "right")'),

--- a/src/Form/Sa11yOptionsForm.php
+++ b/src/Form/Sa11yOptionsForm.php
@@ -113,6 +113,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
       ->set('checkRoot', $form_state->getValue('checkRoot'))
       ->set('containerIgnore', $form_state->getValue('containerIgnore'))
       ->set('contrastIgnore', $form_state->getValue('contrastIgnore'))
+      ->set('linkIgnore', $form_state->getValue('linkIgnore'))
       ->set('exportResultsPlugin', $form_state->getValue('exportResultsPlugin'))
       ->set('checkAllHideToggles', $form_state->getValue('checkAllHideToggles'))
       ->set('panelPosition', $form_state->getValue('panelPosition'))

--- a/src/Form/Sa11yOptionsForm.php
+++ b/src/Form/Sa11yOptionsForm.php
@@ -1,0 +1,113 @@
+<?php  
+
+namespace Drupal\localgov_sa11y\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+  
+class Sa11yOptionsForm extends ConfigFormBase {
+
+  const LOCALGOV_SA11Y_SETTINGS = 'localgov_sa11y_options_form';
+
+   /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'localgov_sa11y_options.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return self::LOCALGOV_SA11Y_SETTINGS;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('localgov_sa11y_options.settings');
+
+    $default_checkRoot_value = $config->get('checkRoot');
+    $form['checkRoot'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Check Root: A single selector to scan a specific region of the page'),
+      '#description' => $this->t('A single selector to scan a specific region of the page. This selector should exist on every page of your website. (Default: \'div.dialog-off-canvas-main-canvas\') '),
+      '#default_value' => !empty($default_checkRoot_value) ? $default_checkRoot_value : 'div.dialog-off-canvas-main-canvas',
+      '#required' => TRUE,
+    ];
+
+    $default_containerIgnore_value = $config->get('containerIgnore');
+    $form['containerIgnore'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Container Ignore: Ignore specific regions of the page'),
+      '#description' => $this->t('List of CSS selectors to have Sa11y completely ignore specifc regions of the page - add each selector on a separate line (Default: \'\') '),
+      '#default_value' => !empty($default_containerIgnore_value) ? $default_containerIgnore_value : '',
+      '#required' => FALSE,
+    ];
+
+    $default_contrastIgnore_value = $config->get('contrastIgnore');
+    $form['contrastIgnore'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Contrast Ignore: Ignore specific elements from the contrast check'),
+      '#description' => $this->t('List of CSS selectors to have sa11y ignore specific elements from the contrast check - add each selector on a separate line (Default: \'\') '),
+      '#default_value' => !empty($default_contrastIgnore_value) ? $default_contrastIgnore_value : '',
+      '#required' => FALSE,
+    ];
+
+    $default_exportResultsPlugin_value = $config->get('exportResultsPlugin');
+    $form['exportResultsPlugin'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow "Export Reports"?'),
+      '#description' => $this->t('Select if you would like to add buttons that allow users to export issues as CSV or HTML (Default: FALSE) '),
+      '#default_value' => !empty($default_exportResultsPlugin_value) ? $default_exportResultsPlugin_value : FALSE,
+      '#required' => FALSE,
+    ];
+
+    $default_checkAllHideToggles_value = $config->get('checkAllHideToggles');
+    $form['checkAllHideToggles'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Visually hide all toggle switches?'),
+      '#description' => $this->t('Select if you would like to visually hide all toggle switches in the Settings panel. This will not hide the Readability, Dark Mode, or Colour Filter toggles (Default: FALSE) '),
+      '#default_value' => !empty($default_checkAllHideToggles_value) ? $default_checkAllHideToggles_value : FALSE,
+      '#required' => FALSE,
+    ];
+
+    $default_panelPosition_value = $config->get('panelPosition');
+    $form['panelPosition'] = [
+      '#type' => 'select',
+      '#options' => [
+        'right' => t('right'),
+        'left' => t('left'),
+        'top-right' => t('top-right'),
+        'top-left' => t('top-left'),
+      ],
+      '#title' => $this->t('Panel position'),
+      '#description' => $this->t('Move position of panel in any four corners. Choose from top-left, top-right, left, and right (Default: \'right\') '),
+      '#default_value' => !empty($default_panelPosition_value) ? $default_panelPosition_value : 'right',
+      '#required' => TRUE,
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('localgov_sa11y_options.settings')
+      ->set('checkRoot', $form_state->getValue('checkRoot'))
+      ->set('containerIgnore', $form_state->getValue('containerIgnore'))
+      ->set('contrastIgnore', $form_state->getValue('contrastIgnore'))
+      ->set('exportResultsPlugin', $form_state->getValue('exportResultsPlugin'))
+      ->set('checkAllHideToggles', $form_state->getValue('checkAllHideToggles'))
+      ->set('panelPosition', $form_state->getValue('panelPosition'))
+      ->save();
+  }
+
+}

--- a/src/Form/Sa11yOptionsForm.php
+++ b/src/Form/Sa11yOptionsForm.php
@@ -13,8 +13,8 @@ class Sa11yOptionsForm extends ConfigFormBase {
   const LOCALGOV_SA11Y_SETTINGS = 'localgov_sa11y_options_form';
 
   /**
-    * {@inheritdoc}
-    */
+   * {@inheritdoc}
+   */
   protected function getEditableConfigNames() {
     return [
       'localgov_sa11y_options.settings',


### PR DESCRIPTION
## Changes

Adds a configuration form so that site admins can do the following:

- Get Sa11y to ignore parts of a page
- Get Sa11ly to ignore contrast issues for certain elements on the page (due to them being hidden or because they are known false positives
- Get Sa11y to ignore certain links (such a links to "#") as these get flagged with a warning/error
- Enable the Export Results function to allow users to export issues as CSV or HTML
- Hide Toggles so that they are always on
- (Re)position the overlay

### Reasoning

See https://github.com/localgovdrupal/localgov_sa11y/issues/43

If content editors can't influence/change the content being highlighted do we actually want it to be highlighted, some content editors may ignore the warnings/errors if they get the impression they can't do anything about them.

Also:
- content editors might want to export the warning/errors to share with another party (or to track them)
- site Admins may not want content editors to selectively turn on/off individual toggles
- having the position of the overlay bottom right may not be convenient

### Installation

This should not affect any existing sites as it is set up to use the "out of the box" defaults for the Sa11y App + the current hard coded `checkRoot` setting