### PR TITLE
Renaming localgov_sa11y_options to localgov_sa11y

### DIFF
--- a/js/localgov-sa11y.js
+++ b/js/localgov-sa11y.js
@@ -2,13 +2,13 @@
   Drupal.behaviors.sa11y = {
     attach: function (context, settings) {
 
-      const checkRootSetting = (drupalSettings.localgov_sa11y_options.checkRoot) ? drupalSettings.localgov_sa11y_options.checkRoot : 'div.dialog-off-canvas-main-canvas';
-      const containerIgnoreSetting = (drupalSettings.localgov_sa11y_options.containerIgnore) ? drupalSettings.localgov_sa11y_options.containerIgnore.replace(/\n/g, ",") : '';
-      const contrastIgnoreSetting = (drupalSettings.localgov_sa11y_options.contrastIgnore) ? drupalSettings.localgov_sa11y_options.contrastIgnore.replace(/\n/g, ",") : '';
-      const linkIgnoreSetting = (drupalSettings.localgov_sa11y_options.linkIgnore) ? drupalSettings.localgov_sa11y_options.linkIgnore.replace(/\n/g, ",") : '';
-      const exportResultsPluginSetting = (drupalSettings.localgov_sa11y_options.exportResultsPlugin) ? drupalSettings.localgov_sa11y_options.exportResultsPlugin : 0;
-      const checkAllHideTogglesSetting = (drupalSettings.localgov_sa11y_options.checkAllHideToggles) ? drupalSettings.localgov_sa11y_options.checkAllHideToggles : 0;
-      const panelPositionSetting = (drupalSettings.localgov_sa11y_options.panelPosition) ? drupalSettings.localgov_sa11y_options.panelPosition : 'right';
+      const checkRootSetting = (drupalSettings.localgov_sa11y.checkRoot) ? drupalSettings.localgov_sa11y.checkRoot : 'div.dialog-off-canvas-main-canvas';
+      const containerIgnoreSetting = (drupalSettings.localgov_sa11y.containerIgnore) ? drupalSettings.localgov_sa11y.containerIgnore.replace(/\n/g, ",") : '';
+      const contrastIgnoreSetting = (drupalSettings.localgov_sa11y.contrastIgnore) ? drupalSettings.localgov_sa11y.contrastIgnore.replace(/\n/g, ",") : '';
+      const linkIgnoreSetting = (drupalSettings.localgov_sa11y.linkIgnore) ? drupalSettings.localgov_sa11y.linkIgnore.replace(/\n/g, ",") : '';
+      const exportResultsPluginSetting = (drupalSettings.localgov_sa11y.exportResultsPlugin) ? drupalSettings.localgov_sa11y.exportResultsPlugin : 0;
+      const checkAllHideTogglesSetting = (drupalSettings.localgov_sa11y.checkAllHideToggles) ? drupalSettings.localgov_sa11y.checkAllHideToggles : 0;
+      const panelPositionSetting = (drupalSettings.localgov_sa11y.panelPosition) ? drupalSettings.localgov_sa11y.panelPosition : 'right';
 
       context = context || document;
       Sa11y.Lang.addI18n(Sa11yLangEn.strings);

--- a/localgov_sa11y.module
+++ b/localgov_sa11y.module
@@ -17,13 +17,13 @@ function localgov_sa11y_page_attachments(array &$page) {
     $page['#attached']['library'][] = 'localgov_sa11y/localgov_sa11y';
   }
 
-  $config = \Drupal::configFactory()->get('localgov_sa11y_options.settings');
+  $config = \Drupal::configFactory()->get('localgov_sa11y.settings');
 
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['checkRoot'] = $config->get('checkRoot');
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['containerIgnore'] = $config->get('containerIgnore');
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['contrastIgnore'] = $config->get('contrastIgnore');
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['linkIgnore'] = $config->get('linkIgnore');
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['exportResultsPlugin'] = $config->get('exportResultsPlugin');
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['checkAllHideToggles'] = $config->get('checkAllHideToggles');
-  $page['#attached']['drupalSettings']['localgov_sa11y_options']['panelPosition'] = $config->get('panelPosition');
+  $page['#attached']['drupalSettings']['localgov_sa11y']['checkRoot'] = $config->get('checkRoot');
+  $page['#attached']['drupalSettings']['localgov_sa11y']['containerIgnore'] = $config->get('containerIgnore');
+  $page['#attached']['drupalSettings']['localgov_sa11y']['contrastIgnore'] = $config->get('contrastIgnore');
+  $page['#attached']['drupalSettings']['localgov_sa11y']['linkIgnore'] = $config->get('linkIgnore');
+  $page['#attached']['drupalSettings']['localgov_sa11y']['exportResultsPlugin'] = $config->get('exportResultsPlugin');
+  $page['#attached']['drupalSettings']['localgov_sa11y']['checkAllHideToggles'] = $config->get('checkAllHideToggles');
+  $page['#attached']['drupalSettings']['localgov_sa11y']['panelPosition'] = $config->get('panelPosition');
 }

--- a/src/Form/Sa11yOptionsForm.php
+++ b/src/Form/Sa11yOptionsForm.php
@@ -13,14 +13,14 @@ class Sa11yOptionsForm extends ConfigFormBase {
 
   use StringTranslationTrait;
 
-  const LOCALGOV_SA11Y_SETTINGS = 'localgov_sa11y_options_form';
+  const LOCALGOV_SA11Y_SETTINGS = 'localgov_sa11y_form';
 
   /**
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
     return [
-      'localgov_sa11y_options.settings',
+      'localgov_sa11y.settings',
     ];
   }
 
@@ -35,7 +35,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $config = $this->config('localgov_sa11y_options.settings');
+    $config = $this->config('localgov_sa11y.settings');
 
     $default_checkRoot_value = $config->get('checkRoot');
     $form['checkRoot'] = [
@@ -115,7 +115,7 @@ class Sa11yOptionsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     parent::submitForm($form, $form_state);
 
-    $this->config('localgov_sa11y_options.settings')
+    $this->config('localgov_sa11y.settings')
       ->set('checkRoot', $form_state->getValue('checkRoot'))
       ->set('containerIgnore', $form_state->getValue('containerIgnore'))
       ->set('contrastIgnore', $form_state->getValue('contrastIgnore'))


### PR DESCRIPTION
### https://github.com/localgovdrupal/localgov_sa11y/pull/44 used the incorrect name for the configuration
`localgov_sa11y_options.settings` was used instead of `localgov_sa11y` causing the following error on `drush cim` after the configuration form had been saved and a `drush cex` had been performed:
```powershell
[error]  Drupal\Core\Config\ConfigImporterException: There were errors validating the config synchronization.
Configuration <em class="placeholder">localgov_sa11y_options.settings</em> depends on the <em class="placeholder">localgov_sa11y_options</em> extension that will not be installed after import. in Drupal\Core\Config\ConfigImporter->validate() (line 823 of D:\NorthKesteven\web\core\lib\Drupal\Core\Config\ConfigImporter.php).
```

This PR resolves the above issue by renaming `localgov_sa11y_options` to `localgov_sa11y` - for anyone who has already updated and saved the configuration form and once this PR has been approved and a there has been a new release,, either deleting the incorrectly named yaml file (`localgov_sa11y_options.settings.yml`) or renaming `localgov_sa11y_options.settings.yml` to `localgov_sa11y.settings.yml` and re-importing the config should resolve it.